### PR TITLE
Bug Fix: OEmbed Component Throws Error

### DIFF
--- a/src/Forms/Components/OEmbed.php
+++ b/src/Forms/Components/OEmbed.php
@@ -2,7 +2,8 @@
 
 namespace FilamentAddons\Forms\Components;
 
-use Closure;
+use Filament\Forms\Get;
+use Filament\Forms\Set;
 use Illuminate\Support\Str;
 use Filament\Forms\Components\Grid;
 use Filament\Forms\Components\Group;
@@ -27,7 +28,7 @@ class OEmbed
                         ->label('URL')
                         ->reactive()
                         ->lazy()
-                        ->afterStateUpdated(function(Closure $set, Closure $get, $state) use ($field) {
+                        ->afterStateUpdated(function (Set $set, Get $get, $state) use ($field) {
                             if ($state) {
                                 $video_url = urlencode($state);
                                 $embed_type = Str::of($state)->contains('vimeo') ? 'vimeo' : 'youtube';
@@ -123,4 +124,3 @@ class OEmbed
         return $outputUrl;
     }
 }
-


### PR DESCRIPTION
### Bug Fix: OEmbed Component Throws Error

**Issue:**
When attempting to use the OEmbed component to enter a YouTube URL, the following error is thrown:

```php
FilamentAddons\Forms\Components\OEmbed::FilamentAddons\Forms\Components\{closure}(): Argument #1 ($set) must be of type Closure, Filament\Forms\Set given, called in /home/abbasmashaddy72/Documents/Sites/Dynamic/cms/vendor/filament/support/src/Concerns/EvaluatesClosures.php on line 35
```

**Resolution:**
To resolve this issue, I made the following changes to the code:

Old Code (Line No: 30):
```php
->afterStateUpdated(function(Closure $set, Closure $get, $state) use ($field) {
```

Updated Code:
```php
->afterStateUpdated(function (Set $set, Get $get, $state) use ($field) {
```

After making this change, the issue was resolved, and the OEmbed component worked as expected.

Thanks to the FilamentAddons package for its valuable contributions in enhancing Filament's admin panel functionality! 👏🎉

I am adding a Pull Request for the Same, I would appreciate it if accepted.